### PR TITLE
v3.1.2 Added download without grouping by manga

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode
 components/__pycache__
-downloads
+downloads*
 *.txt
 *.py_temp
 .env

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Pass the `-r` parameter to download a range of chapters for manga download. You 
 - -j --json (optional. Add the chapter data as found on the api to the archive or folder. Default: True)
 - -r --range (optional. Download a range of chapters, or download all while excluding some. Default: True)
 - -s --search (optional. **NEEDED** to search for manga. Wrap multiple words in quotation marks, e.g. "Please Put These On, Takamine-san". Default: False)
+- -o --order (optional. Download group, user, follows and custom list chapters without grouping them by manga. *This will not create a manga json.*. Default: False)
 - --login (optional. Login to MangaDex. Default: False)
 - --force (optional. Force refresh the downloaded cache. Default: False)
 

--- a/components/__version__.py
+++ b/components/__version__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.1'
+__version__ = '3.1.2'
 __author__ = 'Xunder, Bocchi'
 __url__ = 'https://github.com/Rudoal/mdownloader'
 __license__ = 'GPL v3.0'

--- a/components/exporter.py
+++ b/components/exporter.py
@@ -43,7 +43,9 @@ class ExporterBase:
         Returns:
             int: If the chapter is a oneshot or not.
         """
-        if self.chapter_data["title"].lower() == 'oneshot':
+        if self.chapter_data["title"] is None:
+            return 0
+        elif self.chapter_data["title"].lower() == 'oneshot':
             return 1
         elif self.chapter_data["chapter"] == '' and (self.chapter_data["volume"] == '' or self.chapter_data["volume"] == '0') and self.chapter_data["title"] == '':
             return 1
@@ -51,8 +53,7 @@ class ExporterBase:
             return 2
         elif self.chapter_data["chapter"] == '' and self.chapter_data["volume"] != '' and (self.chapter_data["title"] != '' or self.chapter_data["title"] == ''):
             return 3
-        else:
-            return 0
+        return 0
 
     def format_chapter_number(self) -> str:
         """Format the chapter number into 3 digits long.
@@ -163,7 +164,10 @@ class ExporterBase:
         Returns:
             str: The suffix of the file name.
         """
-        chapter_title = f'{self.chapter_data["title"][:31]}...' if len(self.chapter_data["title"]) > 30 else self.chapter_data["title"]
+        chapter_title = self.chapter_data["title"]
+        if chapter_title is None:
+            chapter_title = ''
+        chapter_title = f'{chapter_title[:31]}...' if len(chapter_title) > 30 else chapter_title
         title = f'[{self.md_model.formatter.strip_illegal(chapter_title)}] ' if len(chapter_title) > 0 else ''
         oneshot_prefix = '[Oneshot] '
         group_suffix = f'[{self.groups}]'

--- a/components/image_downloader.py
+++ b/components/image_downloader.py
@@ -166,12 +166,12 @@ def chapter_downloader(md_model: MDownloader) -> None:
     md_model.exporter = exporter
 
     # Add chapter data to the json for title, group or user downloads
-    if md_model.type_id in (1, 2, 3) or md_model.manga_download:
-        data_to_add = data.copy()
+    data_to_add = data.copy()
+    if md_model.type_id in (1,):
         # data_to_add.update({"mangaData": md_model.manga_data})
         md_model.title_json.chapters(data_to_add)
-        if md_model.type_id in (2, 3):
-            md_model.bulk_json.chapters(data_to_add)
+    if md_model.type_id in (2, 3):
+        md_model.bulk_json.chapters(data_to_add)
 
     print(f'Downloading {title} | Volume: {chapter_data["volume"]} | Chapter: {chapter_data["chapter"]} | Title: {chapter_data["title"]}')
 

--- a/components/jsonmaker.py
+++ b/components/jsonmaker.py
@@ -42,6 +42,13 @@ class JsonBase:
         self.chapters_archive = [c["data"]["id"] for c in self.chapter_data if 'chapters_archive' in c and c["chapters_archive"]] if (self.chapter_data and not self.md_model.force_refresh) else []
         self.chapters_folder = [c["data"]["id"] for c in self.chapter_data if 'chapters_folder' in c and c["chapters_folder"]] if (self.chapter_data and not self.md_model.force_refresh) else []
 
+        if self.md_model.args.folder_download:
+            self.downloaded_ids.extend(self.chapters_folder)
+        else:
+            self.downloaded_ids.extend(self.chapters_archive)
+
+        self.downloaded_ids = list(set(self.downloaded_ids))
+
     def check_json_exist(self) -> dict:
         """Check if the json already exists.
 

--- a/mdownloader.py
+++ b/mdownloader.py
@@ -131,6 +131,7 @@ if __name__ == "__main__":
         help='Download a range of chapters, or all while excluding some. Put "!" in front of the chapters you want to exclude.')
     parser.add_argument('--search', '-s', default=False, const=True, nargs='?', 
         help='Search for the manga specified. Wrap multiple words in quotation marks, e.g. "Please Put These On, Takamine-san"')
+    parser.add_argument('--order', '-o', default=False, const=True, nargs='?', help='Download chapters in descending order instead of grouping by manga.')
     parser.add_argument('--debug', default=False, const=True, nargs='?', help=argparse.SUPPRESS)
     parser.add_argument('--force', default=False, const=True, nargs='?', help='Force refresh the cache.')
     parser.add_argument('--login', default=False, const=True, nargs='?', help='Login to MangaDex.')


### PR DESCRIPTION
**Added:**
- Download group, user, follows, and custom list in the order returned by the API, without grouping the chapters by manga.

**Modified:**
- Fixed NULL title not being detected.

**Removed:**
- Unnecessary code.