### PR TITLE
v3.1.6 Update relationships to use new API scheme

### DIFF
--- a/components/__version__.py
+++ b/components/__version__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.5'
+__version__ = '3.1.6'
 __author__ = 'Xunder, Bocchi'
 __url__ = 'https://github.com/Rudoal/mdownloader'
 __license__ = 'GPL v3.0'

--- a/components/constants.py
+++ b/components/constants.py
@@ -11,8 +11,6 @@ class ImpVar:
     domain = 'mangadex'
     tld = 'org'
 
-    MANGAPLUS_GROUP_ID = '4f1de6a2-f0c5-4ac5-bce5-02c7dbb67deb'
-
     TOKEN_FILE = os.getenv("TOKEN_FILE", '.mdauth')
     CACHE_PATH = os.getenv("CACHE_PATH", '.cache')
     DOWNLOAD_PATH = os.getenv("DOWNLOAD_PATH", 'downloads')
@@ -48,6 +46,6 @@ class ImpVar:
         r'(?::\d+)?' # optional port
         r'(?:/?|[/?]\S+)$', re.IGNORECASE)
 
-    REGEX = r'[\\\\/:*?"<>|]'
+    CHARA_REGEX = r'[\\\\/:*?"<>|]'
     UUID_REGEX = r'[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}'
     FILE_NAME_REGEX = r'(?P<title>.+?)(?:\s\[(?P<language>[a-zA-Z]+)\])?\s-\s(?P<prefix>[c-z])?(?P<chapter>\S+)(?:\s\((?:v)(?P<volume>\S+?)\))?\s?(?:.+)(?:\[(?P<group>.+)\])(?:\{(?:v)(?P<version>\d)\})?(?:\.(?P<extension>zip|cbz))?'

--- a/components/downloader.py
+++ b/components/downloader.py
@@ -109,13 +109,12 @@ def manga_download(md_model: MDownloader) -> None:
     cache_json = md_model.cache.load_cache(manga_id)
     refresh_cache = md_model.cache.check_cache_time(cache_json)
     manga_data = cache_json.get('data', {})
-    relationships = manga_data.get('relationships', [])
 
     if md_model.manga_data and md_model.args.search_manga:
         manga_data = md_model.manga_data
         md_model.cache.save_cache(datetime.now(), manga_id, data=manga_data)
 
-    if refresh_cache or not manga_data or not relationships:
+    if refresh_cache or not manga_data:
         manga_data = md_model.api.get_manga_data(download_type)
         md_model.cache.save_cache(datetime.now(), manga_id, data=manga_data)
         md_model.wait()        
@@ -170,9 +169,8 @@ def bulk_download(md_model: MDownloader) -> None:
         cache_json = md_model.cache.load_cache(md_model.id)
         refresh_cache = md_model.cache.check_cache_time(cache_json)
         data = cache_json.get('data', {})
-        relationships = data.get('relationships', [])
 
-        if refresh_cache or not data or not relationships:
+        if refresh_cache or not data:
             response = md_model.api.request_data(f'{md_model.api_url}/{md_model.download_type}/{md_model.id}', **{"includes[]": ["user", "leader", "member"]})
             data = md_model.api.convert_to_json(md_model.id, download_type, response)
 
@@ -201,7 +199,7 @@ def bulk_download(md_model: MDownloader) -> None:
         md_model.params.update({"uploader": md_model.id})
         md_model.chapter_limit = 100
     elif download_type == 'list':
-        owner = [u for u in md_model.data["relationships"] if u["type"] == 'user'][0]
+        owner = [u for u in md_model.data["data"]["relationships"] if u["type"] == 'user'][0]
         owner = owner["attributes"]["username"]
         md_model.name = f"{owner}'s Custom List"
     else:
@@ -225,7 +223,7 @@ def bulk_download(md_model: MDownloader) -> None:
 
         titles = {}
         for chapter in chapters:
-            manga_id = [c["id"] for c in chapter["relationships"] if c["type"] == 'manga'][0]
+            manga_id = [c["id"] for c in chapter["data"]["relationships"] if c["type"] == 'manga'][0]
             if manga_id in titles:
                 titles[manga_id]["chapters"].append(chapter)
             else:

--- a/components/image_downloader.py
+++ b/components/image_downloader.py
@@ -111,7 +111,7 @@ async def image_download(
                     extension = image.split('.', 1)[1]
 
                     # Add image to archive
-                    exporter.add_image(img_data, page_no, extension)
+                    exporter.add_image(img_data, page_no, extension, image)
 
                     retry = retry_max_times
 

--- a/components/jsonmaker.py
+++ b/components/jsonmaker.py
@@ -31,8 +31,6 @@ class JsonBase:
 
         self.id = data["data"]["id"]
         self.data = data["data"]["attributes"]
-        self.relationsips = data["relationships"]
-
         self.route.mkdir(parents=True, exist_ok=True)
         self.json_path = self.route.joinpath(f'{file_prefix}{self.id}_data').with_suffix('.json')
 
@@ -101,7 +99,6 @@ class JsonBase:
         else:
             self.new_data = self.bulk_data
 
-        self.new_data["relationships"] = self.relationsips
         self.new_data["chapters"] = self.chapter_data
         self.save_json()
 
@@ -113,7 +110,7 @@ class TitleJson(JsonBase):
         super().__init__(md_model)
         self.download_type = md_model.download_type
         self.save_covers = md_model.args.cover_download
-        self.regex = re.compile(ImpVar.REGEX)
+        self.regex = re.compile(ImpVar.CHARA_REGEX)
 
         # Make the covers folder in the manga folder
         if self.save_covers:


### PR DESCRIPTION
**Added:**
- Save chapters and pages using either incrementing numbers or original names retrieved from the API.
- Extra checking for empty results.

**Modified:**
- Relationship code to use relationship key part of the data object, not the soon-to-be depreciated external key.