### PR TITLE
v3.2.1 Add renaming folders and files if they are using a title that isn't the main title

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Pass the `-r` parameter to download a range of chapters for manga download. You 
 - -s --search (optional. **NEEDED** to search for manga. Wrap multiple words in quotation marks, e.g. "Please Put These On, Takamine-san". Default: False)
 - -o --order (optional. Download group, user, follows and custom list chapters without grouping them by manga. *This will not create a manga json.*. Default: False)
 - --login (optional. Login to MangaDex. Default: False)
-- --force (optional. Force refresh the downloaded cache. Default: False)
+- --refresh (optional. Force refresh the downloaded cache. Default: False)
+- --update (optional. Skip looking for an application update. Default: False)
+- --rename (optional. Skip renaming downloaded files if the title is wrong. Default: True)
 
 ## Blacklisting and Whitelisting
 ***Whitelisting takes priority with group filtering taking priority over user filtering.***

--- a/components/__version__.py
+++ b/components/__version__.py
@@ -1,4 +1,4 @@
-__version__ = '3.2.0'
+__version__ = '3.2.1'
 __author__ = 'Xunder, Bocchi'
 __url__ = 'https://github.com/Rudoal/mdownloader'
 __license__ = 'GPL v3.0'

--- a/components/exporter.py
+++ b/components/exporter.py
@@ -133,7 +133,7 @@ class ExporterBase:
         if len(group_names) == 0:
             group_names.append('no group')
 
-        return self.md_model.formatter.strip_illegal(', '.join(group_names))
+        return self.md_model.formatter.strip_illegal_characters(', '.join(group_names))
 
     def suffix_name(self) -> str:
         """Formats the groups as the suffix of the file name."""
@@ -142,7 +142,7 @@ class ExporterBase:
             chapter_title = ''
 
         chapter_title = f'{chapter_title[:31]}...' if len(chapter_title) > 30 else chapter_title
-        title = f'[{self.md_model.formatter.strip_illegal(chapter_title)}] ' if len(chapter_title) > 0 else ''
+        title = f'[{self.md_model.formatter.strip_illegal_characters(chapter_title)}] ' if len(chapter_title) > 0 else ''
         oneshot_prefix = '[Oneshot] '
         group_suffix = f'[{self.groups}]'
 

--- a/components/image_downloader.py
+++ b/components/image_downloader.py
@@ -163,7 +163,6 @@ def chapter_downloader(md_model: MDownloader) -> None:
         return
 
     pages = chapter_data["data"]
-
     if not pages:
         raise MDownloaderError('This chapter has no pages.')
 
@@ -183,7 +182,7 @@ def chapter_downloader(md_model: MDownloader) -> None:
 
     # Download images
     for image in pages:
-        task = asyncio.ensure_future(image_download(md_model, url, fallback_url, image, pages, exporter))
+        task = loop.create_task(image_download(md_model, url, fallback_url, image, pages, exporter))
         tasks.append(task)
 
     runner = display_progress(tasks)

--- a/components/model.py
+++ b/components/model.py
@@ -372,10 +372,12 @@ class DataFormatter(ModelsBase):
         if not available_titles:
             return
 
-        print(f"Renaming files and folders with {new_title}'s other titles.")
-
         if new_title in available_titles:
             available_titles.remove(new_title)
+            if not available_titles:
+                return
+
+        print(f"Renaming files and folders with {new_title}'s other titles.")
 
         processes = []
         for title in available_titles:
@@ -658,9 +660,8 @@ class Filtering(ModelsBase):
         if self.group_whitelist or self.user_whitelist:
             if self.group_whitelist:
                 chapters = [c for c in chapters if [g for g in c["relationships"] if g["type"] == 'scanlation_group' and g["id"] in self.group_whitelist]]
-            else:
-                if self.user_whitelist:
-                    chapters = [c for c in chapters if [u for u in c["relationships"] if u["type"] == 'user' and u["id"] in self.user_whitelist]]
+            if self.user_whitelist:
+                chapters = [c for c in chapters if [u for u in c["relationships"] if u["type"] == 'user' and u["id"] in self.user_whitelist]]
         else:
             chapters = [c for c in chapters if 
                 (([g for g in c["relationships"] if g["type"] == 'scanlation_group' and g["id"] not in self.group_blacklist]) 

--- a/mdownloader.py
+++ b/mdownloader.py
@@ -145,6 +145,7 @@ if __name__ == "__main__":
     parser.add_argument('--refresh', default=False, const=True, nargs='?', help='Force refresh the cache.')
     parser.add_argument('--login', default=False, const=True, nargs='?', help='Login to MangaDex.')
     parser.add_argument('--update', default=False, const=True, nargs='?', help='Skip looking for an application update.')
+    parser.add_argument('--rename', default=True, const=False, nargs='?', help='Skip renaming downloaded files if the title is wrong.')
     parser.add_argument('id', help='ID to download. Can be chapter, manga, group, user, list, link/id or file.')
 
     args = parser.parse_args()


### PR DESCRIPTION
**Added:**
- Rename old series folders if they're using a different title to that of MangaDex.
- rename argument to skip renaming folders.

**Modified:**
- Fix cover download.
- Whitelist users for downloads with group whitelist.
- Use loop.create_task() instead of asyncio.ensure_future().
- Update readme.