### PR TITLE
v3.2.7 update for API depreciation

### DIFF
--- a/components/__version__.py
+++ b/components/__version__.py
@@ -1,4 +1,4 @@
-__version__ = '3.2.6'
+__version__ = '3.2.7'
 __author__ = 'Xunder'
 __url__ = 'https://github.com/Rudoal/mdownloader'
 __license__ = 'GPL v3.0'

--- a/components/model.py
+++ b/components/model.py
@@ -791,16 +791,9 @@ class MDownloaderMisc(ModelsBase):
         url = None
 
         if 'externalUrl' in chapter_data:
-            if chapter_data["externalUrl"] is not None and chapter_data["externalUrl"] != '':
+            if chapter_data["externalUrl"] is not None:
                 url = chapter_data["externalUrl"]
                 external = True
-
-        if not external and bool(ImpVar.URL_RE.match(chapter_data["data"][0])):
-            url = chapter_data["data"][0]
-            external = True
-
-        if len(chapter_data["data"]) > 1:
-            external = False
 
         if external:
             if any(s in url for s in ('mangaplus',)):


### PR DESCRIPTION
**Modified:**
- Chapter pages and hash are now under the At-home endpoint, change to use it.
- Change fallback URL to only be called if needed, not before the image downloader is called.

**Removed:**
- Checking if the pages array is full for external checking.